### PR TITLE
Don't require history.length for SSR scenarios

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ export const history = PropTypes.shape({
   goBack: PropTypes.func.isRequired,
   goForward: PropTypes.func.isRequired,
   index: PropTypes.number, // only in createMemoryHistory
-  length: PropTypes.number.isRequired,
+  length: PropTypes.number, // not required for StaticRouter
   listen: PropTypes.func.isRequired,
   location: location.isRequired,
   push: PropTypes.func.isRequired,


### PR DESCRIPTION
In SSR scenarios with react-router, StaticRouter is used and therefore no history is injected. This means that `history.length` is `undefined` when using the HOC `withRouter` and hence, propType validation will fail.