### PR TITLE
✨Feature/static context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
 dist/
+
+# editos
+.vscode

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router-prop-types",
-  "version": "1.0.3",
+  "version": "1.1.3",
   "description": "Runtime type checking for react-router props",
   "main": "dist/index.js",
   "types": "dist/index.d.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,9 +49,12 @@ routeShape.routes = PropTypes.arrayOf(PropTypes.shape(routeShape));
 
 export const route = PropTypes.shape(routeShape);
 
+export const staticContext = PropTypes.object; // for simple usage
+
 export default {
   location,
   history,
   match,
   route,
+  staticContext,
 };


### PR DESCRIPTION
### Actions
- ✨Add `staticContext` proptype.

### Description
The out of the box version is for simple usage like with `withRouter`; for more advanced usage the user should use custom proptypes for the custom context.

> When a `<Route>` matches, it will pass the context object to the component it renders as the `staticContext` prop. Check out the [Server Rendering guide](../../../react-router-dom/docs/guides/server-rendering.md) for more information on how to do this yourself. [Docs](https://github.com/ReactTraining/react-router/edit/master/packages/react-router/docs/api/StaticRouter.md)

### Typical use case
- Using `withRouter` and desctructuring the props using `...rest`, React would throw and unknown prop on html dom element error, thus we need to filter the `staticContext` and thefore having to declare its proptypes. (usually `PropTypes.object` is forbidden with eslint guidlines like airbnb, declaring it in ReactRouterPropTypes solves the issue.)