### PR TITLE
Wrong warnings fixes because of history v 5.0.0 hidden changes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,8 +21,8 @@ export const history = PropTypes.shape({
   createHref: PropTypes.func.isRequired,
   entries: PropTypes.arrayOf(location), // only in createMemoryHistory
   go: PropTypes.func.isRequired,
-  goBack: PropTypes.func.isRequired,
-  goForward: PropTypes.func.isRequired,
+  back: PropTypes.func.isRequired,
+  forward: PropTypes.func.isRequired,
   index: PropTypes.number, // only in createMemoryHistory
   length: PropTypes.number,
   listen: PropTypes.func.isRequired,


### PR DESCRIPTION
Renamed goBack to back and goForward to forward due to history 5v changes https://github.com/ReactTraining/history/issues/811 to fix warnings